### PR TITLE
Use universe polymorphism so we can construct a category of categories

### DIFF
--- a/coq/CategoryTheory/Category.v
+++ b/coq/CategoryTheory/Category.v
@@ -8,8 +8,8 @@
 
 (* Metavariables for categories: C, D, E *)
 
-Record category := newCategory {
-  object : Type; (* Metavariables for objects: w, x, y, z *)
+Polymorphic Record category := newCategory {
+  object :> Type; (* Metavariables for objects: w, x, y, z *)
   arrow : object -> object -> Type; (* Metavariables for arrows: f, g, h *)
   compose : forall {x y z}, arrow y z -> arrow x y -> arrow x z;
   id : forall {x}, arrow x x;
@@ -23,9 +23,9 @@ Record category := newCategory {
     (forall (f : arrow y x), compose f id = f);
 }.
 
-Hint Resolve cAssoc.
-Hint Resolve (fun C x y => proj1 (cIdent C x y)).
-Hint Resolve (fun C x y => proj2 (cIdent C x y)).
-Hint Rewrite cAssoc.
-Hint Rewrite (fun C x y => proj1 (cIdent C x y)).
-Hint Rewrite (fun C x y => proj2 (cIdent C x y)).
+Polymorphic Hint Resolve cAssoc.
+Polymorphic Hint Resolve (fun C x y => proj1 (cIdent C x y)).
+Polymorphic Hint Resolve (fun C x y => proj2 (cIdent C x y)).
+Polymorphic Hint Rewrite cAssoc.
+Polymorphic Hint Rewrite (fun C x y => proj1 (cIdent C x y)).
+Polymorphic Hint Rewrite (fun C x y => proj2 (cIdent C x y)).

--- a/coq/Kleene.v
+++ b/coq/Kleene.v
@@ -6,6 +6,7 @@
 (********************************************************)
 (********************************************************)
 
+Require Import Main.Tactics.
 Require Import Nat.
 Require Import Omega.
 
@@ -94,28 +95,6 @@ Module Type Kleene.
     | 0 => bottom
     | S n => f (approx f n)
     end.
-
-  (*******************)
-  (* Helpful tactics *)
-  (*******************)
-
-  (*
-    This tactic is useful if you have a hypothesis H : P -> Q and you want to
-    use Q. You can just write `feed H`. A new proof obligation for P will be
-    generated, and then the hypothesis will be specialized to H : Q.
-  *)
-
-  Ltac feed H1 := let H2 := fresh "H" in
-    match type of H1 with
-    | ?T -> _ => assert (H2 : T); [ | specialize (H1 H2); clear H2 ]
-    end.
-
-  (*
-    This tactic takes a given term and adds its type to the context as a new
-    hypothesis.
-  *)
-
-  Ltac fact E := let H := fresh "H" in pose (H := E); clearbody H.
 
   (******************)
   (* Helpful lemmas *)


### PR DESCRIPTION
Use universe polymorphism so we can construct a category of categories. Also, remove some redundant tactics.