### PR TITLE
Update the Makefile to clean up temporary files even when the build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,14 @@
 all: main lint
 
 main:
-	rm -f CoqMakefile _CoqProjectFull
+	rm -f Makefile.coq _CoqProjectFull
 	echo '-R coq Main' > _CoqProjectFull
 	find coq -type f -name '*.v' >> _CoqProjectFull
-	coq_makefile -f _CoqProjectFull -o CoqMakefile
-	make -f CoqMakefile
-	rm -f CoqMakefile _CoqProjectFull
+	coq_makefile -f _CoqProjectFull -o Makefile.coq || \
+	  (rm -f Makefile.coq _CoqProjectFull; exit 1)
+	make -f Makefile.coq || \
+	  (rm -f Makefile.coq _CoqProjectFull; exit 1)
+	rm -f Makefile.coq _CoqProjectFull
 
 lint:
 	./scripts/check-line-lengths.sh \
@@ -27,7 +29,7 @@ lint:
 	  )
 
 clean:
-	rm -f _CoqProjectFull CoqMakefile \
+	rm -f _CoqProjectFull Makefile.coq \
 	  $(shell find . -type f \( \
 	    -name '*.glob' -o \
 	    -name '*.v.d' -o \


### PR DESCRIPTION
Update the Makefile to clean up temporary files even when the build fails.