### PR TITLE
Remove the functional extensionality axiom from the Cat proof, since it's not used

### DIFF
--- a/coq/CategoryTheory/Cat.v
+++ b/coq/CategoryTheory/Cat.v
@@ -6,7 +6,6 @@
 (******************************************************************)
 (******************************************************************)
 
-Require Import Coq.Logic.FunctionalExtensionality.
 Require Import Coq.Logic.ProofIrrelevance.
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Functor.


### PR DESCRIPTION
Remove the functional extensionality axiom from the `Cat` proof, since it's not used.