### PR TITLE
Switch from eauto to auto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ dist: trusty
 language: generic
 sudo: required
 services: docker
-script: make docker-build
+script:
+  - while sleep 1m; do echo "=====[ still running ]====="; done &
+  - make docker-build
+  - kill %1

--- a/coq/Intro.v
+++ b/coq/Intro.v
@@ -129,7 +129,13 @@ Lemma doubleInd :
   P n /\ P (succ n).
 Proof.
   intros.
-  induction n; try destruct IHn; auto.
+  induction n.
+  - split; assumption.
+  - destruct IHn.
+    split.
+    + assumption.
+    + apply H1.
+      split; assumption.
 Qed.
 
 (* Now we can prove the main result: forall n, even n \/ odd n. *)
@@ -137,9 +143,13 @@ Qed.
 Theorem evenOrOdd : forall n, even n \/ odd n.
 Proof.
   apply doubleInd.
-  - left; apply evenZero.
-  - right; apply oddOne.
-  - intros; destruct H; destruct H; destruct H0;
+  - left.
+    apply evenZero.
+  - right.
+    apply oddOne.
+  - intros.
+    destruct H.
+    destruct H; destruct H0;
       left + right; apply evenSS + apply oddSS; assumption.
 Qed.
 
@@ -151,5 +161,7 @@ Proof.
   intros.
   induction n.
   - reflexivity.
-  - cbn; rewrite IHn; reflexivity.
+  - cbn.
+    rewrite IHn.
+    reflexivity.
 Qed.

--- a/coq/Kleene.v
+++ b/coq/Kleene.v
@@ -7,8 +7,6 @@
 (********************************************************)
 
 Require Import Main.Tactics.
-Require Import Nat.
-Require Import Omega.
 
 Module Type Kleene.
   (***************)
@@ -27,6 +25,10 @@ Module Type Kleene.
   Axiom refl : forall x, leq x x.
   Axiom trans : forall x y z, leq x y -> leq y z -> leq x z.
   Axiom antisym : forall x y, leq x y -> leq y x -> x = y.
+
+  Hint Resolve refl.
+  Hint Resolve trans.
+  Hint Resolve antisym.
 
   (*
     A supremum of a subset of T is a least element of T which is greater than
@@ -57,6 +59,8 @@ Module Type Kleene.
     directed P ->
     exists x, supremum P x.
 
+  Hint Resolve directedComplete.
+
   (*
     Assumption: Let T have a least element called bottom. This makes our
     partial order a pointed directed-complete partial order.
@@ -65,6 +69,8 @@ Module Type Kleene.
   Parameter bottom : T.
 
   Axiom bottomLeast : forall x, leq bottom x.
+
+  Hint Resolve bottomLeast.
 
   (*
     A monotone function is one which preserves order. We only need to consider
@@ -102,16 +108,18 @@ Module Type Kleene.
 
   (* We will need this simple lemma about pairs of natural numbers. *)
 
-  Lemma natDiff : forall n1 n2, exists n3, n1 = add n2 n3 \/ n2 = add n1 n3.
+  Lemma natDiff : forall n1 n2, exists n3, n1 = n2 + n3 \/ n2 = n1 + n3.
   Proof.
     induction n1; intros.
-    - exists n2; right; auto.
+    - exists n2; magic.
     - specialize (IHn1 n2); destruct IHn1; destruct H.
-      + exists (S x); left; rewrite H; omega.
+      + exists (S x); magic.
       + destruct x.
-        * exists 1; left; omega.
-        * exists x; right; rewrite H; omega.
+        * exists 1; magic.
+        * exists x; magic.
   Qed.
+
+  Hint Resolve natDiff.
 
   (* The supremum of a subset of T, if it exists, is unique. *)
 
@@ -122,12 +130,12 @@ Module Type Kleene.
     x1 = x2.
   Proof.
     intros.
-    unfold supremum in H; destruct H.
-    unfold supremum in H0; destruct H0.
-    apply H1 in H0.
-    apply H2 in H.
-    apply antisym; auto.
+    unfold supremum in H.
+    unfold supremum in H0.
+    magic.
   Qed.
+
+  Hint Resolve supremumUniqueness.
 
   (* Scott-continuity implies monotonicity. *)
 
@@ -140,46 +148,39 @@ Module Type Kleene.
     feed H.
     - unfold directed.
       split.
-      + exists x1; auto.
+      + exists x1; magic.
       + intros.
         destruct H1;
           rewrite H1;
           exists x2;
           split;
-          [ auto | | try apply refl | ].
+          magic.
         * {
           destruct H2; rewrite H2.
-          - auto.
+          - magic.
           - split.
             + apply refl.
-            + right; auto.
+            + right; magic.
         }
         * {
           split.
-          - destruct H2; rewrite H2.
-            + auto.
-            + apply refl.
-          - right; auto.
+          - destruct H2; magic.
+          - magic.
         }
     - feed H.
       + unfold supremum.
         split.
-        * {
-          intros.
-          destruct H1; rewrite H1; auto || apply refl.
-        }
-        * {
-          intros.
-          specialize (H1 x2).
-          feed H1; auto.
-        }
+        * intros; destruct H1; magic.
+        * magic.
       + unfold supremum in H.
         destruct H.
         specialize (H (f x1)).
         feed H.
-        * exists x1; auto.
-        * auto.
+        * exists x1; magic.
+        * magic.
   Qed.
+
+  Hint Resolve continuousImpliesMonotone.
 
   (*
     Iterated applications of a monotone function f to bottom form an ω-chain,
@@ -195,21 +196,11 @@ Module Type Kleene.
     intros.
     fact (natDiff n m).
     destruct H0; destruct H0.
-    - right.
-      rewrite H0; clear H0.
-      generalize x.
-      induction m; intros.
-      + cbn; apply bottomLeast.
-      + specialize (IHm x0); apply H in IHm.
-        cbn; auto.
-    - left.
-      rewrite H0; clear H0.
-      generalize x.
-      induction n; intros.
-      + cbn; apply bottomLeast.
-      + specialize (IHn x0); apply H in IHn.
-        cbn; auto.
+    - right; subst n; induction m; magic.
+    - left; subst m; induction n; magic.
   Qed.
+
+  Hint Resolve omegaChain.
 
   (* The ascending Kleene chain of f is directed. *)
 
@@ -222,7 +213,7 @@ Module Type Kleene.
     set (P := fun x2 : T => exists n : nat, x2 = approx f n).
     unfold directed.
     split.
-    - exists bottom; unfold P; exists 0; auto.
+    - exists bottom; unfold P; exists 0; magic.
     - intros.
       unfold P in H0; destruct H0.
       unfold P in H1; destruct H1.
@@ -230,23 +221,25 @@ Module Type Kleene.
       destruct H2.
       + exists x2.
         split.
-        * rewrite H0; rewrite H1; auto.
+        * magic.
         * {
           split.
           - apply refl.
           - unfold P.
-            exists x0; auto.
+            exists x0; magic.
         }
       + exists x1.
         split.
-        * apply refl.
+        * magic.
         * {
           split.
-          - rewrite H0; rewrite H1; auto.
+          - magic.
           - unfold P.
-            exists x; auto.
+            exists x; magic.
         }
   Qed.
+
+  Hint Resolve kleeneChainDirected.
 
   (**********************************)
   (* The Kleene fixed-point theorem *)
@@ -269,10 +262,10 @@ Module Type Kleene.
     intros.
     set (P := fun x2 : T => exists n : nat, x2 = approx f n).
     assert (directed P).
-    - apply kleeneChainDirected; apply continuousImpliesMonotone in H; auto.
+    - apply kleeneChainDirected; apply continuousImpliesMonotone in H; magic.
     - fact (directedComplete P H0); destruct H1.
       exists x.
-      split; auto.
+      split; magic.
       split.
       + unfold continuous in H.
         specialize (H P x H0 H1).
@@ -291,10 +284,10 @@ Module Type Kleene.
                 exists (approx f x0).
                 split.
                 - unfold P.
-                  exists x0; auto.
-                - cbn in H2; auto.
+                  exists x0; magic.
+                - magic.
               }
-              * apply H; auto.
+              * magic.
           - unfold supremum in H; destruct H.
             apply H3.
             intros.
@@ -304,9 +297,9 @@ Module Type Kleene.
             unfold P in H4; destruct H4.
             rewrite H4 in H5.
             exists (S x1).
-            cbn; auto.
+            magic.
         }
-        * apply (supremumUniqueness P); auto.
+        * apply (supremumUniqueness P); magic.
       + intros.
         assert (forall x3, P x3 -> leq x3 x2).
         * {
@@ -314,17 +307,16 @@ Module Type Kleene.
           unfold P in H3; destruct H3.
           generalize dependent x3.
           induction x0; intros.
-          - cbn in H3; rewrite H3; apply bottomLeast.
-          - specialize (IHx0 (approx f x0)); feed IHx0; auto.
+          - cbn in H3; subst x3; magic.
+          - specialize (IHx0 (approx f x0)); feed IHx0; magic.
             rewrite H3; clear H3.
             cbn.
             rewrite <- H2.
             fact (continuousImpliesMonotone f H).
-            apply H3; auto.
+            magic.
         }
-        * {
-          unfold supremum in H1; destruct H1.
-          apply H4; auto.
-        }
+        * unfold supremum in H1; magic.
   Qed.
+
+  Hint Resolve kleene.
 End Kleene.

--- a/coq/Reflection.v
+++ b/coq/Reflection.v
@@ -6,6 +6,8 @@
 (************************************************************************)
 (************************************************************************)
 
+Require Import Main.Tactics.
+
 (**********************)
 (* General reflection *)
 (**********************)
@@ -14,31 +16,17 @@ Inductive reflect (P : Prop) : bool -> Prop :=
 | reflectT : P -> reflect P true
 | reflectF : ~ P -> reflect P false.
 
+Hint Constructors reflect.
+
 Theorem reflectIff : forall P b, (P <-> b = true) <-> reflect P b.
 Proof.
-  intros P b.
-  split.
-  - intros H1.
-    destruct b.
-    + apply reflectT.
-      apply (proj2 H1).
-      reflexivity.
-    + apply reflectF.
-      unfold not.
-      intros H2.
-      apply (proj1 H1) in H2.
-      inversion H2.
-  - intros H1.
-    split.
-    + intros H2.
-      destruct H1 as [H3 H4 | H3 H4].
-      * reflexivity.
-      * contradiction.
-    + intros H2.
-      destruct H1 as [H3 H4 | H3 H4].
-      * auto.
-      * inversion H2.
+  split; intros.
+  - destruct b; magic.
+  - split; intros; destruct H; magic.
 Qed.
+
+Hint Resolve -> reflectIff.
+Hint Resolve <- reflectIff.
 
 (*********************)
 (* Example: evenness *)
@@ -53,6 +41,8 @@ Qed.
 Inductive even : nat -> Prop :=
 | evenZero : even 0
 | evenSS : forall n : nat, even n -> even (S (S n)).
+
+Hint Constructors even.
 
 Fixpoint isEven n :=
   match n with
@@ -71,57 +61,33 @@ Lemma evenInd :
   forall n,
   P n /\ P (S n).
 Proof.
-  intros P H1 H2 H3.
-  induction n as [| n H4].
-  - auto.
-  - destruct H4 as [H4 H5].
-    auto.
+  induction n; magic.
 Qed.
+
+Hint Resolve evenInd.
 
 Theorem evenIffIsEven : forall n, even n <-> isEven n = true.
 Proof.
-  intros n.
-  split.
-  - intros H1.
-    induction H1 as [| n H1 H2].
-    + reflexivity.
-    + auto.
+  intros; split.
+  - intros; induction H; magic.
   - generalize dependent n.
     set (P := fun n => isEven n = true -> even n).
-    assert (forall n, P n /\ P (S n)) as H1.
-    + apply evenInd.
-      * unfold P.
-        intros H.
-        apply evenZero.
-      * unfold P.
-        intros H.
-        simpl in H.
-        inversion H.
-      * unfold P.
-        intros n H1 H3.
-        destruct H1 as [H1 H2].
-        apply evenSS.
-        simpl in H3.
-        apply H1 in H3.
-        auto.
-    + intros n.
-      set (H2 := H1 n).
-      destruct H2 as [H2 H3].
-      unfold P in H2.
-      auto.
+    assert (forall n, P n /\ P (S n)).
+    + apply evenInd; unfold P; magic.
+    + intros; specialize (H n); magic.
 Qed.
+
+Hint Resolve -> evenIffIsEven.
+Hint Resolve <- evenIffIsEven.
 
 Theorem evenRefl : forall n, reflect (even n) (isEven n).
 Proof.
-  intros n.
-  apply reflectIff.
-  apply evenIffIsEven.
+  magic.
 Qed.
 
 (* A proof by reflection of (even 1000) *)
 
 Lemma evenOneThousand : even 1000.
 Proof.
-  apply evenIffIsEven.
-  reflexivity.
+  magic.
 Qed.

--- a/coq/Stlc/Progress.v
+++ b/coq/Stlc/Progress.v
@@ -16,19 +16,20 @@ Theorem progress :
   hasType cEmpty e1 t ->
   value e1 \/ exists e2, step e1 e2.
 Proof.
-  remember cEmpty.
-  intros.
-  induction H; magic.
-  - feed IHhasType1; magic; destruct IHhasType1.
-    + inversion H2; inversion H; magic.
-    + destruct H2; right; exists (eIf x e2 e3); magic.
-  - rewrite Heqc in H; inversion H.
-  - feed IHhasType1; magic; feed IHhasType2; magic.
-    destruct IHhasType1; destruct IHhasType2.
-    + inversion H2; magic; rewrite <- H3 in H0; inversion H0.
-    + destruct H2; right; exists (eApp x e1); magic.
-    + destruct H1; right; exists (eApp e2 x); magic.
-    + destruct H1; destruct H2; right; exists (eApp x0 e1); magic.
+  intros; remember cEmpty; induction H; magic.
+  - right. destruct IHhasType1; magic.
+    + destruct H2.
+      * exists e2; magic.
+      * exists e3; magic.
+      * inversion H.
+    + destruct H2; exists (eIf x e2 e3); magic.
+  - subst c; inversion H.
+  - right; destruct IHhasType1; destruct IHhasType2; magic.
+    + inversion H2; inversion H0; magic.
+      exists (sub e x e1); magic.
+    + destruct H2; exists (eApp x e1); magic.
+    + destruct H1; exists (eApp e2 x); magic.
+    + destruct H2; exists (eApp x e1); magic.
 Qed.
 
 Hint Resolve progress.

--- a/coq/Stlc/Soundness.v
+++ b/coq/Stlc/Soundness.v
@@ -19,5 +19,9 @@ Theorem soundness :
   stepStar e1 e2 ->
   (value e2 \/ exists e3, step e2 e3).
 Proof.
-  intros; induction H0; magic.
+  intros; induction H0.
+  - apply progress with (t := t); magic.
+  - feed IHstepStar.
+    + apply preservation with (e1 := e1); magic.
+    + magic.
 Qed.

--- a/coq/Tactics.v
+++ b/coq/Tactics.v
@@ -8,18 +8,28 @@
 
 Require Import Omega.
 
+(* This tactic removes superfluous hypotheses. *)
+
+Ltac clean := repeat (
+  match goal with
+  | [ H : ?x = ?y |- _ ] => (is_var y; subst x) || (is_var x; subst y)
+  | [ H : ?x = ?x |- _ ] => clear H
+  end
+).
+
 (*
   This tactic tries a variety of approaches to solve a goal. It uses the
   resolve, rewrite, and unfold hints from the "core" database.
 *)
 
 Ltac magic := try abstract (
+  clean;
   cbn;
   intros;
   f_equal;
   idtac + autounfold with core in *;
   idtac + autorewrite with core in *;
-  omega + congruence + dintuition eauto with *
+  omega + congruence + dintuition
 ).
 
 (*


### PR DESCRIPTION
Switch from `eauto` to `auto` in the `magic` tactic to make the proofs less magical.