### PR TITLE
Don't use \/ or /\ in inductive propositions

### DIFF
--- a/coq/STLC/FreeVars.v
+++ b/coq/STLC/FreeVars.v
@@ -12,9 +12,17 @@ Require Import Main.STLC.Syntax.
 Import Name.
 
 Inductive freeVar : term -> name -> Prop :=
-| fIf :
+| fIf1 :
   forall e1 e2 e3 x,
-  freeVar e1 x \/ freeVar e2 x \/ freeVar e3 x ->
+  freeVar e1 x ->
+  freeVar (eIf e1 e2 e3) x
+| fIf2 :
+  forall e1 e2 e3 x,
+  freeVar e2 x ->
+  freeVar (eIf e1 e2 e3) x
+| fIf3 :
+  forall e1 e2 e3 x,
+  freeVar e3 x ->
   freeVar (eIf e1 e2 e3) x
 | fVar :
   forall x,

--- a/coq/STLC/Preservation.v
+++ b/coq/STLC/Preservation.v
@@ -24,9 +24,6 @@ Lemma contextInvariance :
 Proof.
   intros. generalize dependent c2.
   induction H; magic; intros.
-  - apply htIf;
-      apply IHhasType1 + apply IHhasType2 + apply IHhasType3;
-      intros; apply H2; magic.
   - apply htVar. rewrite <- H0; magic.
   - apply htAbs. apply IHhasType. intros. cbn.
     destruct (nameEq x0 x); magic. apply H0. magic.


### PR DESCRIPTION
Don't use `\/` or `/\` in inductive propositions, since that prevents Coq from generating good induction hypotheses.

After eliminating these from the `fIf` case by splitting it into three separate cases, I was able to delete part of a proof since Coq is now able to automate that part.