### PR TITLE
Don't use eauto in magic

### DIFF
--- a/coq/Kleene.v
+++ b/coq/Kleene.v
@@ -156,6 +156,7 @@ Module Type Kleene.
         * intros. destruct H1; subst x0; magic.
         * magic.
       + unfold supremum in H. destruct H. specialize (H (f x1)). feed H.
+        exists x1. magic.
   Qed.
 
   Hint Resolve continuousImpliesMonotone.

--- a/coq/STLC/Preservation.v
+++ b/coq/STLC/Preservation.v
@@ -39,8 +39,10 @@ Theorem typingJudgmentClosed :
   exists t2, lookupVar c x = Some t2.
 Proof.
   intros. induction H; invert H0; magic.
-  feed IHhasType. destruct IHhasType. cbn in H0.
-  destruct (nameEq x x0); magic.
+  - exists t. magic.
+  - feed IHhasType. destruct IHhasType. cbn in H0.
+    destruct (nameEq x x0); magic.
+    exists x1. magic.
 Qed.
 
 Hint Resolve typingJudgmentClosed.
@@ -68,6 +70,7 @@ Proof.
       apply contextInvariance with (c1 := cExtend (cExtend c x t1) n t); magic.
       intros. cbn.
       destruct (nameEq x0 n); destruct (nameEq x0 x); magic.
+  - apply htApp with (t2 := t3); magic.
 Qed.
 
 Hint Resolve substitutionPreservesTyping.
@@ -82,8 +85,10 @@ Proof.
   remember cEmpty. induction H; subst c; intros; try abstract (invert H0).
   - invert H2; magic.
   - invert H1; magic.
-    apply substitutionPreservesTyping with (t1 := t2); magic.
-    invert H; magic.
+    + apply substitutionPreservesTyping with (t1 := t2); magic.
+      invert H; magic.
+    + apply htApp with (t2 := t2); magic.
+    + apply htApp with (t2 := t2); magic.
 Qed.
 
 Hint Resolve preservation.

--- a/coq/STLC/Progress.v
+++ b/coq/STLC/Progress.v
@@ -18,10 +18,15 @@ Theorem progress :
   value e1 \/ exists e2, step e1 e2.
 Proof.
   intros. remember cEmpty. induction H; subst c; magic.
-  - right. destruct IHhasType1; magic.
-    destruct H2; magic.
+  - right. destruct IHhasType1; magic; destruct H2; magic.
+    + exists e2. magic.
+    + exists e3. magic.
+    + exists (eIf x e2 e3). magic.
   - right. destruct IHhasType1; destruct IHhasType2; magic.
-    invert H; invert H1; magic.
+    + invert H; invert H1; magic. exists (sub e x e2). magic.
+    + destruct H2. exists (eApp e1 x). magic.
+    + destruct H1. exists (eApp x e2). magic.
+    + destruct H1. exists (eApp x e2). magic.
 Qed.
 
 Hint Resolve progress.

--- a/coq/STLC/Soundness.v
+++ b/coq/STLC/Soundness.v
@@ -19,7 +19,9 @@ Theorem soundness :
   stepStar e1 e2 ->
   (value e2 \/ exists e3, step e2 e3).
 Proof.
-  intros. induction H0; magic.
+  intros. induction H0.
+  - apply progress with (t := t). magic.
+  - feed IHstepStar. apply preservation with (e1 := e1); magic.
 Qed.
 
 Hint Resolve soundness.

--- a/coq/Tactics.v
+++ b/coq/Tactics.v
@@ -34,9 +34,7 @@ Ltac magic :=
     auto with *;
     try abstract (dintuition (simplify; auto with *));
     try congruence;
-    try omega;
-    eauto with *;
-    dintuition (simplify; eauto with *)
+    try omega
   in try abstract (
     simplify;
     idtac + f_equal;


### PR DESCRIPTION
Don't use `eauto` in `magic`. It's too slow.